### PR TITLE
Removing incorrect query parameter route

### DIFF
--- a/accessing-session-data.mdx
+++ b/accessing-session-data.mdx
@@ -96,9 +96,6 @@ The methods above return risk scores and flags. To retrieve a detailed log of ev
 GET https://api.roundtable.ai/v1/sessions/{sessionId}/events
 ```
 
-> **This route is also available using query parameters:**  
-> `GET https://api.roundtable.ai/v1/sessions/events?sessionId={sessionId}`
-
 ### Example request
 
 ```bash


### PR DESCRIPTION
Self-explanatory - we do no support the query parameter route for session events so we are removing that from our documentation.