### PR TITLE
changelog: filtering by flag on dashboard

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,9 @@ description: "Latest updates and improvements to Proof of Human."
 ## July 2026
 
 <AccordionGroup>
+  <Accordion title="New: Filtering by flag on dashboard">
+    Added the ability to filter sessions by flag directly on the dashboard. Clicking a flag in the flags detected table opens the session list filtered to sessions where that flag fired.
+  </Accordion>
   <Accordion title="Update: Improved dashboard visibility">
     Improved the visibility of the dashboard by adding new visualizations and metrics on the main dashboard page.
   </Accordion>


### PR DESCRIPTION
Changelog entry for [roundtableAI/app#162](https://github.com/roundtableAI/app/pull/162), which makes flag labels in the dashboard "flags detected" table link to the session list filtered to that flag (`/sessions?flag=<key>`).

Wording follows the existing "Filtering by tag and route on dashboard" entry from March 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)