### PR TITLE
Changelog: Visitor IDs dashboard page

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,7 +7,7 @@ description: "Latest updates and improvements to Proof of Human."
 
 <AccordionGroup>
   <Accordion title="New: Visitor IDs dashboard page">
-    Added a Visitor IDs page to the dashboard that groups sessions by visitor ID, ordered by most recent session, with a filter for duplicate visitors. Clicking a visitor opens a summary with lifetime session and risk statistics, flag rates, the tags, routes, user IDs, and locations associated with the visitor, and links to their sessions.
+    Added a Visitor IDs page to the dashboard that provides summaries and recent histories for each visitor.
   </Accordion>
   <Accordion title="Update: Visitor ID model">
     Updated the visitor ID fingerprinting model to reduce false positives when identifying duplicate devices.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,9 @@ description: "Latest updates and improvements to Proof of Human."
 ## August 2026
 
 <AccordionGroup>
+  <Accordion title="New: Visitor IDs dashboard page">
+    Added a Visitor IDs page to the dashboard that groups sessions by visitor ID, ordered by most recent session, with a filter for duplicate visitors. Clicking a visitor opens a summary with lifetime session and risk statistics, flag rates, the tags, routes, user IDs, and locations associated with the visitor, and links to their sessions.
+  </Accordion>
   <Accordion title="Update: Visitor ID model">
     Updated the visitor ID fingerprinting model to reduce false positives when identifying duplicate devices.
   </Accordion>


### PR DESCRIPTION
Adds the new Visitor IDs dashboard page (ProofOfHumanPBC/app#176) to the August 2026 changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)